### PR TITLE
[closes #2] Add exact-matching for generated /index

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ There isn't much in the way of config options:
 		        generated /index. They are resolved relative to index.root
 		  -index.root string
 		        the root serving directory (default current directory)
-		  -serve.home string
-		        the file returned if '/' is requested; resolved relative to server.root (default "README.md")
+		  -serve.default string
+		        the file returned if '/' is requested; resolved relative to index.root (default "README.md")
 		  -serve.ip string
 		        the interface we should be listening on (default "localhost")
 		  -serve.port int
@@ -38,7 +38,7 @@ There isn't much in the way of config options:
 All requests are resolved relative to `-index.root`. Relative links in your
 docs that need to descend below root will not resolve correctly.
 
-Typical usage for me looks lomething like `markup -serve.index README.md` which
+Typical usage for me looks lomething like `markup -serve.default SOMEFILE.md` which
 will end up dropped into `handbook.sh`, `engdocs.sh`, and the like.
 
 ## Caching!

--- a/app/handlers.go
+++ b/app/handlers.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"path"
 	"sort"
-	"strings"
 
 	"github.com/falun/markup/buildindex"
 )
@@ -72,12 +71,12 @@ func serveIndex(indexToken, browseToken, root string, excluding []string) http.H
 
 	return func(rw http.ResponseWriter, r *http.Request) {
 		// searching is the directory we're looking for; "." if empty
-		searching := path.Clean(r.URL.Path[len(indexToken)+2:])
+		searching := path.Clean(r.URL.Path[len(indexToken)+1:])
 
-		if searching != "." {
+		if !(searching == "." || searching == "/") {
 			contents := ""
 			for _, c := range fileset {
-				if strings.HasSuffix(c.Root, searching) {
+				if c.Root[len(root):] == searching {
 					contents += mkEntry(c)
 				}
 			}

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func main() {
 	flag.StringVar(&host, "serve.ip", host, "the interface we should be listening on")
 	flag.IntVar(&port, "serve.port", port, "the port markup will listen on")
 	flag.StringVar(
-		&index, "serve.home", index,
+		&index, "serve.default", index,
 		"the file returned if '/' is requested; resolved relative to server.root")
 	flag.StringVar(
 		&exclude, "index.exclude", exclude,


### PR DESCRIPTION
Does what it says. Requesting `/index/oo` will now return only the `oo` directory and not `foo`, `boo`, `woo`, etc.
